### PR TITLE
Fix typos and browser alias; add vitest test

### DIFF
--- a/browser-extension/background.js
+++ b/browser-extension/background.js
@@ -1,6 +1,8 @@
 // Background service worker for PriceWise Smart Shopping Assistant
 // Cross-browser compatibility layer
-const browser = chrome || browser;
+const browser = typeof chrome !== 'undefined' ? chrome :
+                typeof browser !== 'undefined' ? browser :
+                undefined;
 
 // Extension lifecycle management
 browser.runtime.onInstalled.addListener((details) => {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@capacitor/android": "^7.4.2",
@@ -88,6 +89,7 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vitest": "^1.4.0"
   }
 }

--- a/src/utils/billOCR.ts
+++ b/src/utils/billOCR.ts
@@ -228,7 +228,7 @@ export const extractTextFromImage = async (file: File): Promise<string> => {
     
     console.log('Processing image file with enhanced OCR...');
     
-    // Enhanced OCR with multiple language support and better settings
+    // Enhanced OCR with improved settings (English language)
     const result = await Tesseract.recognize(file, 'eng', {
       logger: m => {
         if (m.status === 'recognizing text') {

--- a/src/utils/smartCategorization.ts
+++ b/src/utils/smartCategorization.ts
@@ -45,7 +45,7 @@ const CATEGORY_RULES: Record<string, CategoryRule> = {
   
   'Office Supplies': {
     keywords: [
-      'office', 'supplies', 'stationary', 'paper', 'printer', 'toner', 'ink',
+      'office', 'supplies', 'stationery', 'paper', 'printer', 'toner', 'ink',
       'staples', 'office depot', 'best buy', 'amazon business', 'costco business',
       'furniture', 'desk', 'chair', 'equipment', 'electronics'
     ],

--- a/tests/smartCategorization.test.ts
+++ b/tests/smartCategorization.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { categorizeExpense } from '../src/utils/smartCategorization'
+
+describe('categorizeExpense', () => {
+  it('categorizes internet-related expense', () => {
+    const result = categorizeExpense('Monthly bill', 'Comcast', 'internet service')
+    expect(result.category).toBe('Internet/Telecom')
+  })
+
+  it('returns Other for unknown expense', () => {
+    const result = categorizeExpense('Random purchase')
+    expect(result.category).toBe('Other')
+  })
+})


### PR DESCRIPTION
## Summary
- fix Office Supplies keyword typo (`stationery`)
- fix browser compatibility alias in extension background script
- clarify OCR comment in `billOCR.ts`
- add `vitest` and a small unit test for `categorizeExpense`

## Testing
- `npm test` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687f30ff32d08327a26da4dc9757d7a3